### PR TITLE
opentelemetry-instrumentation-asgi 0.59b0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ test:
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi
+  dev_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi
+  doc_url: https://opentelemetry.io/docs/
   summary: ASGI instrumentation for OpenTelemetry
   license: Apache-2.0
   license_family: APACHE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,6 @@ about:
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  doc_url: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html
-  dev_url: https://github.com/open-telemetry/opentelemetry-python-contrib
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,17 @@ about:
   dev_url: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi
   doc_url: https://opentelemetry.io/docs/
   summary: ASGI instrumentation for OpenTelemetry
+  description: |
+    OpenTelemetry instrumentation for ASGI applications. Wraps an ASGI
+    callable to automatically generate spans for incoming requests,
+    propagate trace context, and emit standard HTTP semantic-convention
+    attributes. Used by other instrumentation plugins (e.g. FastAPI) and
+    can be applied directly to any ASGI framework.
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
+  doc_url: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html
+  dev_url: https://github.com/open-telemetry/opentelemetry-python-contrib
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,47 +1,49 @@
 {% set name = "opentelemetry-instrumentation-asgi" %}
-{% set version = "0.36b0" %}
+{% set version = "0.59b0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_asgi-{{ version }}.tar.gz
-  sha256: 6a271d895d5eae4d98484be60abbc407871bf0dfd1dcfe916f38bf0260e79757
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_instrumentation_asgi-{{ version }}.tar.gz
+  sha256: 2509d6fe9fd829399ce3536e3a00426c7e3aa359fc1ed9ceee1628b56da40e7a
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - hatchling
   run:
-    - python >=3.7
-    - asgiref >=3.0,<4.dev0
-    - opentelemetry-api >=1.12,<2.dev0
-    - opentelemetry-instrumentation ==0.36b0
-    - opentelemetry-semantic-conventions ==0.36b0
-    - opentelemetry-util-http ==0.36b0
+    - python
+    - asgiref >=3.0,<4
+    - opentelemetry-api >=1.12,<2
+    - opentelemetry-instrumentation ==0.59b0
+    - opentelemetry-semantic-conventions ==0.59b0
+    - opentelemetry-util-http ==0.59b0
 
 test:
   imports:
     - opentelemetry
-    - opentelemetry.instrumentation
-  commands:
-    - pip check
+    - opentelemetry.instrumentation.asgi
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi
   summary: ASGI instrumentation for OpenTelemetry
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
     - mariusvniekerk
+    - rxm7706


### PR DESCRIPTION
opentelemetry-instrumentation-asgi 0.59b0

**Destination channel:** defaults

### Links

- [PKG-14504](https://anaconda.atlassian.net/browse/PKG-14504) (blocks PKG-14500 → PKG-7382 chromadb)
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asgi)
- Conda-forge recipe: https://github.com/conda-forge/opentelemetry-instrumentation-asgi-feedstock/blob/main/recipe/meta.yaml

### Explanation of changes:

- **first potential release** AnacondaRecipes fork has been at v0.36b0 (very stale) and never released. Required transitively by `opentelemetry-instrumentation-fastapi` (PKG-14500), which is required by chromadb 1.5.8 (PKG-7382).
- **Version 0.36b0 → 0.59b0** to match the OpenTelemetry Python Contrib suite already on pkgs/main:
  - `opentelemetry-instrumentation 0.59b0`
  - `opentelemetry-semantic-conventions 0.59b0`
  - `opentelemetry-util-http 0.59b0`

  Going to the latest `0.62b1` would force bumping all three of those siblings together (they all pin each other with `==X.YYbN` from the synchronized monorepo release).
- **Adaptations:**
  - Improve test import to `opentelemetry.instrumentation.asgi` (more specific than just `opentelemetry.instrumentation`).
- **Upstream-verified deps:** [`pyproject.toml`](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/v1.38.0/instrumentation/opentelemetry-instrumentation-asgi/pyproject.toml) declares hatchling backend (no separate `wheel` needed) and runtime deps `asgiref ~=3.0`, `opentelemetry-api ~=1.12`, plus `==0.59b0` pins on three sibling packages.

[PKG-14504]: https://anaconda.atlassian.net/browse/PKG-14504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ